### PR TITLE
Add iOS project configuration files

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,0 +1,18 @@
+name: iOS CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install XcodeGen
+        run: brew install xcodegen
+      - name: Generate Xcode project
+        run: xcodegen generate
+      - name: Build (Simulator)
+        run: xcodebuild -project WebhookChat.xcodeproj -scheme WebhookChat -destination 'platform=iOS Simulator,name=iPhone 15' build

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>WebhookChat</string>
+  <key>UILaunchScreen</key>
+  <dict/>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Mikrofon wird für Sprachnachrichten benötigt.</string>
+  <key>NSSpeechRecognitionUsageDescription</key>
+  <string>Spracherkennung zur Transkription von Voice Messages.</string>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,25 @@
+name: WebhookChat
+options:
+  minimumXcodeGenVersion: 2.41.0
+targets:
+  WebhookChat:
+    type: application
+    platform: iOS
+    deploymentTarget: "17.0"
+    sources:
+      - path: App/Sources
+      - path: App/Resources
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.yourcompany.webhookchat
+        INFOPLIST_FILE: Info.plist
+        SWIFT_VERSION: 5.9
+    scheme:
+      testTargets: [WebhookChatTests]
+  WebhookChatTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources: [App/Tests]
+    settings:
+      base:
+        TEST_HOST: ""


### PR DESCRIPTION
## Summary
- add XcodeGen project definition for the WebhookChat iOS app
- include Info.plist with required bundle metadata and privacy descriptions
- set up GitHub Actions workflow to generate and build the app project on macOS runners

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad9a17ab48324b11ddab802646a1a