### PR TITLE
Add chat models

### DIFF
--- a/App/Sources/Models/ChatModels.swift
+++ b/App/Sources/Models/ChatModels.swift
@@ -1,0 +1,38 @@
+import Foundation
+import SwiftData
+
+enum Role: String, Codable, CaseIterable {
+    case user, assistant, system
+}
+
+@Model final class Conversation {
+    @Attribute(.unique) var id: UUID
+    var title: String
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(id: UUID = UUID(), title: String, createdAt: Date = .now, updatedAt: Date = .now) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+@Model final class Message {
+    @Attribute(.unique) var id: UUID
+    var conversationId: UUID
+    var roleRaw: String
+    var content: String
+    var createdAt: Date
+
+    var role: Role { Role(rawValue: roleRaw) ?? .user }
+
+    init(id: UUID = UUID(), conversationId: UUID, role: Role, content: String, createdAt: Date = .now) {
+        self.id = id
+        self.conversationId = conversationId
+        self.roleRaw = role.rawValue
+        self.content = content
+        self.createdAt = createdAt
+    }
+}


### PR DESCRIPTION
## Summary
- add Role enum to represent participant roles in chat conversations
- create SwiftData Conversation model with unique ID and timestamps
- create SwiftData Message model with stored role string and computed Role helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cadd4755f88324987acdfb7fb83bbb