### PR TITLE
Add webhook client and audio speech service

### DIFF
--- a/App/Sources/Services/AudioAndSpeech.swift
+++ b/App/Sources/Services/AudioAndSpeech.swift
@@ -1,0 +1,51 @@
+import Foundation
+import AVFoundation
+import Speech
+
+@MainActor
+final class AudioSpeechService: NSObject, AVAudioRecorderDelegate {
+    private var recorder: AVAudioRecorder?
+    private let audioSession = AVAudioSession.sharedInstance()
+    private let recognizer = SFSpeechRecognizer()
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private let request = SFSpeechAudioBufferRecognitionRequest()
+    private let engine = AVAudioEngine()
+
+    func requestPermissions() async throws {
+        let micOk = try await audioSession.requestRecordPermission()
+        guard micOk else { throw NSError(domain: "mic", code: 1) }
+        _ = SFSpeechRecognizer.authorizationStatus()
+        // App fragt beim ersten Start automatisch um Erlaubnis (Info.plist Texte vorhanden)
+    }
+
+    func transcribeLive() async throws -> AsyncStream<String> {
+        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true)
+
+        let input = engine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.request.append(buffer)
+        }
+        engine.prepare()
+        try engine.start()
+
+        let stream = AsyncStream<String> { cont in
+            recognitionTask = recognizer?.recognitionTask(with: request) { result, error in
+                if let t = result?.bestTranscription.formattedString {
+                    cont.yield(t)
+                }
+                if let _ = error { cont.finish() }
+                if result?.isFinal == true { cont.finish() }
+            }
+        }
+        return stream
+    }
+
+    func stopTranscription() {
+        engine.stop()
+        engine.inputNode.removeTap(onBus: 0)
+        request.endAudio()
+        recognitionTask?.cancel()
+    }
+}

--- a/App/Sources/Services/WebhookClient.swift
+++ b/App/Sources/Services/WebhookClient.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+struct WebhookClient {
+    struct Payload: Codable {
+        struct Msg: Codable { let role: String; let content: String }
+        let conversationId: UUID
+        let messages: [Msg]
+        let metadata: [String:String]?
+    }
+    struct Response: Codable {
+        let conversationId: UUID
+        let reply: String
+        let metadata: [String:String]?
+    }
+
+    var baseURL: URL
+    var apiKey: String? // optional, falls in n8n benötigt
+
+    func send(conversationId: UUID, messages: [(Role,String)], timeout: TimeInterval = 30) async throws -> String {
+        var request = URLRequest(url: baseURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let apiKey { request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization") }
+        let payload = Payload(
+            conversationId: conversationId,
+            messages: messages.map { .init(role: $0.0.rawValue, content: $0.1) },
+            metadata: ["client":"ios","appVersion":"1.0"]
+        )
+        request.httpBody = try JSONEncoder().encode(payload)
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = timeout
+        let (data, resp) = try await URLSession(configuration: config).data(for: request)
+        guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+        let res = try JSONDecoder().decode(Response.self, from: data)
+        return res.reply
+    }
+}


### PR DESCRIPTION
## Summary
- add a service for sending webhook conversations with optional API key authentication
- add an audio speech service handling live transcription

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cadd513b4083248e2c6c5af7e77a2f