### PR TITLE
Add chat UI and view models

### DIFF
--- a/App/Sources/App/WebhookChatApp.swift
+++ b/App/Sources/App/WebhookChatApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import SwiftData
+
+@main
+struct WebhookChatApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ChatListView()
+        }
+        .modelContainer(for: [Conversation.self, Message.self])
+    }
+}

--- a/App/Sources/ViewModels/ChatViewModel.swift
+++ b/App/Sources/ViewModels/ChatViewModel.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftData
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    @Published var input: String = ""
+    @Published var isSending = false
+    @Published var error: String?
+    var client: WebhookClient
+    var modelContext: ModelContext
+    var conversation: Conversation
+
+    init(client: WebhookClient, context: ModelContext, conversation: Conversation) {
+        self.client = client
+        self.modelContext = context
+        self.conversation = conversation
+    }
+
+    var messages: [Message] {
+        let q = FetchDescriptor<Message>(predicate: #Predicate { $0.conversationId == conversation.id },
+                                         sortBy: [SortDescriptor(\.createdAt, order: .forward)])
+        return (try? modelContext.fetch(q)) ?? []
+    }
+
+    func send() async {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        input = ""
+        let userMsg = Message(conversationId: conversation.id, role: .user, content: trimmed)
+        modelContext.insert(userMsg)
+        try? modelContext.save()
+
+        isSending = true; defer { isSending = false }
+        do {
+            let history = messages.map { ($0.role, $0.content) } + [(.user, trimmed)]
+            let reply = try await client.send(conversationId: conversation.id, messages: history)
+            let bot = Message(conversationId: conversation.id, role: .assistant, content: reply)
+            conversation.updatedAt = .now
+            modelContext.insert(bot)
+            try? modelContext.save()
+        } catch {
+            self.error = "Fehler: \(error.localizedDescription)"
+        }
+    }
+}

--- a/App/Sources/Views/ChatUI.swift
+++ b/App/Sources/Views/ChatUI.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+import SwiftData
+
+struct ChatListView: View {
+    @Environment(\.modelContext) private var ctx
+    @Query(sort: \Conversation.updatedAt, order: .reverse) private var convos: [Conversation]
+    @State private var showingSettings = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(convos) { c in
+                    NavigationLink(destination: ChatDetailView(conversation: c)) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(c.title).font(.headline)
+                            Text(c.updatedAt, style: .date).font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .onDelete { idx in idx.map { convos[$0] }.forEach { ctx.delete($0) } }
+            }
+            .navigationTitle("Chats")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button { showingSettings = true } label: { Image(systemName: "gear") }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        let c = Conversation(title: "Neuer Chat")
+                        ctx.insert(c)
+                        try? ctx.save()
+                    } label: { Image(systemName: "plus") }
+                }
+            }
+            .sheet(isPresented: $showingSettings) { SettingsView() }
+        }
+    }
+}
+
+struct ChatDetailView: View {
+    @Environment(\.modelContext) private var ctx
+    @AppStorage("webhookURL") private var webhookURL: String = ""
+    @AppStorage("apiKey") private var apiKey: String = ""
+    let conversation: Conversation
+    @StateObject private var vmHolder = _VMHolder()
+
+    var body: some View {
+        let url = URL(string: webhookURL.isEmpty ? "https://example.com" : webhookURL)!
+        let client = WebhookClient(baseURL: url, apiKey: apiKey.isEmpty ? nil : apiKey)
+        let vm = vmHolder.provide { ChatViewModel(client: client, context: ctx, conversation: conversation) }
+
+        VStack {
+            List(vm.messages) { msg in
+                HStack(alignment: .top) {
+                    if msg.role == .assistant { Spacer(minLength: 24) }
+                    Text(msg.content)
+                        .padding(10)
+                        .background(msg.role == .user ? Color.blue.opacity(0.1) : Color.gray.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                    if msg.role == .user { Spacer(minLength: 24) }
+                }
+                .listRowSeparator(.hidden)
+            }
+            .listStyle(.plain)
+
+            HStack {
+                TextField("Nachricht…", text: $vm.input, axis: .vertical)
+                    .textFieldStyle(.roundedBorder)
+                Button {
+                    Task { await vm.send() }
+                } label: {
+                    if vm.isSending { ProgressView() } else { Image(systemName: "paperplane.fill") }
+                }
+                .disabled(vm.isSending)
+            }
+            .padding()
+        }
+        .navigationTitle(conversation.title)
+        .alert(isPresented: Binding(get: { vm.error != nil }, set: { _ in vm.error = nil })) {
+            Alert(title: Text("Fehler"), message: Text(vm.error ?? ""), dismissButton: .default(Text("OK")))
+        }
+    }
+}
+
+private final class _VMHolder: ObservableObject {
+    var instance: ChatViewModel?
+    func provide(_ build: () -> ChatViewModel) -> ChatViewModel {
+        if let i = instance { return i }
+        let i = build(); instance = i; return i
+    }
+}

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("webhookURL") private var webhookURL: String = ""
+    @AppStorage("apiKey") private var apiKey: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Endpoint") {
+                    TextField("Webhook URL (https://…)", text: $webhookURL)
+                        .keyboardType(.URL)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+                    SecureField("API Key (optional)", text: $apiKey)
+                }
+                Section {
+                    Text("Die App sendet JSON an den n8n-Workflow und erwartet JSON mit `reply` zurück.")
+                        .font(.footnote).foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("Einstellungen")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a chat list/detail interface with SwiftUI for managing conversations
- implement a chat view model that sends messages via a webhook client and stores them with SwiftData
- create a settings screen and main app entry to configure webhook access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cadd5ad19c832480bc40675688b4b3