### PR TITLE
Add placeholder unit test target sources

### DIFF
--- a/App/Tests/WebhookChatTests.swift
+++ b/App/Tests/WebhookChatTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import WebhookChat
+
+final class WebhookChatTests: XCTestCase {
+    func testAppEntryPointIsAvailable() throws {
+        let app = ExplorerAgentApp()
+        _ = app.body
+    }
+}


### PR DESCRIPTION
## Summary
- add the missing App/Tests directory expected by the WebhookChatTests target
- include a basic XCTest case that instantiates the ExplorerAgentApp entry point

## Testing
- xcodegen generate *(fails: `xcodegen` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0c1c624883249ac202eada703d96