### PR TITLE
Align Xcode project naming with ExplorerAgent target

### DIFF
--- a/App/Tests/ExplorerAgentTests.swift
+++ b/App/Tests/ExplorerAgentTests.swift
@@ -1,7 +1,7 @@
 import XCTest
-@testable import WebhookChat
+@testable import ExplorerAgent
 
-final class WebhookChatTests: XCTestCase {
+final class ExplorerAgentTests: XCTestCase {
     func testAppEntryPointIsAvailable() throws {
         let app = ExplorerAgentApp()
         _ = app.body

--- a/project.yml
+++ b/project.yml
@@ -1,9 +1,9 @@
-name: WebhookChat
+name: ExplorerAgent
 options:
   minimumXcodeGenVersion: 2.41.0
   xcodeVersion: "15.4"
 targets:
-  WebhookChat:
+  ExplorerAgent:
     type: application
     platform: iOS
     deploymentTarget: "17.0"
@@ -12,12 +12,12 @@ targets:
       - path: App/Resources
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.yourcompany.webhookchat
+        PRODUCT_BUNDLE_IDENTIFIER: com.yourcompany.exploreragent
         INFOPLIST_FILE: Info.plist
         SWIFT_VERSION: 5.9
     scheme:
-      testTargets: [WebhookChatTests]
-  WebhookChatTests:
+      testTargets: [ExplorerAgentTests]
+  ExplorerAgentTests:
     type: bundle.unit-test
     platform: iOS
     sources: [App/Tests]


### PR DESCRIPTION
## Summary
- rename the generated Xcode project configuration to `ExplorerAgent`
- update bundle identifier and scheme to match the ExplorerAgent target name
- rename the unit test target and imports to align with the ExplorerAgent module

## Testing
- not run (Xcode tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb0d006d048324841b99eeca7063f3