### PR TITLE
feat(theme): default dark mode + theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A Next.js 14 chat interface that speaks to configurable webhooks (e.g. n8n workf
 - **Local persistence** via IndexedDB (conversations/messages) and export/import as JSON
 - **Audio messages** recorded in-browser and proxied as `multipart/form-data`
 - **Settings** for per-user webhook override, extra headers, and streaming toggle
-- **Secure proxy** with domain allowlist, header filtering, rate limiting, body limits and timeouts
+- **Secure proxy** with URL validation, header filtering, rate limiting, body limits and timeouts
 
 ## Getting Started
 
@@ -65,14 +65,11 @@ Create a `.env.local` based on `.env.example`:
 
 ```
 N8N_DEFAULT_WEBHOOK_URL=https://hooks.n8n.cloud/your-flow
-WEBHOOK_ALLOWLIST=hooks.n8n.cloud,example.com
 MAX_REQUEST_BYTES=5000000
 REQUEST_TIMEOUT_MS=30000
 NEXT_PUBLIC_APP_NAME=Explorer Agent
 NEXT_PUBLIC_APP_VERSION=0.1.0
 ```
-
-`WEBHOOK_ALLOWLIST` must include every domain you plan to contact (including ports if applicable).
 
 ### Commands
 
@@ -131,7 +128,7 @@ return [
 
 ## Security
 
-- **Allowlist enforcement** – only domains in `WEBHOOK_ALLOWLIST` are reachable.
+- **URL validation** – outbound webhook URLs must be syntactically valid.
 - **Header filtering** – only `X-API-KEY`, `X-WORKFLOW-ID`, `X-SESSION-ID`, `X-CLIENT-ID`, `X-REQUEST-ID` are forwarded.
 - **Rate limiting** – token bucket (60 req/min/IP) on proxy routes.
 - **Body limits** – rejects bodies over 5 MB and audio files exceeding the limit.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -204,7 +204,7 @@ export async function POST(request: NextRequest) {
     targetUrl = assertAllowedUrl(payload.userWebhook || getDefaultWebhook());
   } catch (error) {
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Webhook not allowed' },
+      { error: error instanceof Error ? error.message : 'Invalid webhook URL' },
       { status: 400 },
     );
   }

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,17 +1,13 @@
 import { NextResponse } from 'next/server';
 
-import { getAllowlist, getDefaultWebhook } from '@/lib/proxy';
+import { getDefaultWebhook } from '@/lib/proxy';
 
 export const runtime = 'nodejs';
 
 export function GET() {
-  const allowlist = getAllowlist();
   const defaultWebhook = getDefaultWebhook();
   const missing: string[] = [];
 
-  if (allowlist.length === 0) {
-    missing.push('WEBHOOK_ALLOWLIST');
-  }
   if (!process.env.MAX_REQUEST_BYTES) {
     missing.push('MAX_REQUEST_BYTES');
   }
@@ -27,5 +23,5 @@ export function GET() {
         : 'Ready to accept requests.'
       : `Missing configuration: ${missing.join(', ')}`;
 
-  return NextResponse.json({ status, allowlist, message, defaultWebhook });
+  return NextResponse.json({ status, message, defaultWebhook });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,44 +3,97 @@
 @tailwind utilities;
 
 :root {
-  --background: 210 40% 98%;
-  --foreground: 222.2 47.4% 11.2%;
+  /* Light (nur wenn .light auf <html>) */
+  --bg: #ffffff;
+  --surface: #f6f7f8;
+  --text: #0b0c0e;
+  --muted: #6b7177;
+  --ring: rgba(10, 132, 255, 0.35);
+  --grad-from: #f7e433; /* aiti-gold-200 */
+  --grad-to: #ecaf3b; /* aiti-gold-500 */
+
+  --background: 0 0% 100%;
+  --foreground: 220 14% 6%;
   --card: 0 0% 100%;
-  --card-foreground: 222.2 47.4% 11.2%;
+  --card-foreground: 220 14% 6%;
   --popover: 0 0% 100%;
-  --popover-foreground: 222.2 47.4% 11.2%;
-  --primary: 221.2 83.2% 53.3%;
-  --primary-foreground: 210 40% 98%;
-  --secondary: 210 40% 96.1%;
-  --secondary-foreground: 222.2 47.4% 11.2%;
-  --muted: 210 40% 96.1%;
-  --muted-foreground: 215.4 16.3% 46.9%;
-  --accent: 210 40% 96.1%;
-  --accent-foreground: 222.2 47.4% 11.2%;
-  --destructive: 0 100% 50%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 214.3 31.8% 91.4%;
-  --input: 214.3 31.8% 91.4%;
-  --ring: 221.2 83.2% 53.3%;
-  --radius: 0.75rem;
+  --popover-foreground: 220 14% 6%;
+  --primary: 40 92% 56%;
+  --primary-foreground: 220 14% 12%;
+  --secondary: 210 25% 92%;
+  --secondary-foreground: 220 18% 18%;
+  --muted-foreground: 215 15% 46%;
+  --accent: 216 100% 64%;
+  --accent-foreground: 0 0% 100%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 210 25% 90%;
+  --input: 210 25% 90%;
+  --ring-hsl: 216 100% 64%;
+  --radius: 1rem;
+
+  color-scheme: light;
+}
+
+.dark {
+  --bg: #121418; /* neu-900 */
+  --surface: #16181c; /* dunkle Fläche */
+  --text: #f7f8fa;
+  --muted: #9aa1a9;
+  --ring: rgba(10, 132, 255, 0.5);
+  --grad-from: #f5cd39; /* aiti-gold-300 */
+  --grad-to: #c59c3e; /* aiti-gold-600 */
+
+  --background: 220 18% 8%;
+  --foreground: 215 20% 96%;
+  --card: 220 20% 11%;
+  --card-foreground: 215 20% 96%;
+  --popover: 220 20% 11%;
+  --popover-foreground: 215 20% 96%;
+  --primary: 40 92% 56%;
+  --primary-foreground: 216 28% 12%;
+  --secondary: 220 19% 20%;
+  --secondary-foreground: 215 20% 92%;
+  --muted-foreground: 214 18% 74%;
+  --accent: 216 100% 64%;
+  --accent-foreground: 215 20% 96%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 215 20% 96%;
+  --border: 215 19% 24%;
+  --input: 215 19% 24%;
+  --ring-hsl: 216 100% 64%;
+
+  color-scheme: dark;
 }
 
 * {
   @apply border-border;
 }
 
+html,
 body {
-  @apply bg-background text-foreground font-sans antialiased;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--text);
 }
 
-html, body {
-  height: 100%;
+body {
+  @apply font-sans antialiased;
 }
 
 #__next {
-  height: 100%;
+  min-height: 100%;
 }
 
-a {
-  @apply text-primary underline-offset-4 hover:underline;
+.aiti-gradient {
+  background: linear-gradient(135deg, var(--grad-from), var(--grad-to));
+}
+
+.surface {
+  background: var(--surface);
+}
+
+.focus-ring {
+  @apply focus-visible:outline-none focus-visible:ring-2;
+  box-shadow: 0 0 0 2px var(--ring);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,13 @@
-import type { Metadata } from 'next';
 import './globals.css';
+import { ThemeProvider } from 'next-themes';
+import type { Metadata } from 'next';
 
-import { cn } from '@/lib/utils';
 import { Toaster } from '@/components/ui/toaster';
+import { cn } from '@/lib/utils';
 
 export const metadata: Metadata = {
-  title: process.env.NEXT_PUBLIC_APP_NAME || 'Explorer Agent',
-  description: 'Chat UI for webhook-driven agents',
+  title: 'Explorer Agent',
+  description: 'AI Training Institute – We apply AI',
 };
 
 export default function RootLayout({
@@ -15,12 +16,19 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body
-        className={cn('min-h-screen bg-background font-sans text-foreground')}
-      >
-        <div className="flex min-h-screen flex-col">{children}</div>
-        <Toaster />
+    <html lang="de" suppressHydrationWarning>
+      <body className={cn('min-h-screen font-sans antialiased')}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <div className="flex min-h-screen flex-col bg-[var(--bg)] text-[var(--text)]">
+            {children}
+          </div>
+          <Toaster />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,39 +5,45 @@ import {
   ResizablePanel,
   ResizableHandle,
 } from '@/components/ui/resizable';
+import ThemeToggle from '@/components/ui/ThemeToggle';
 
 export default function HomePage() {
   return (
-    <main className="flex h-full flex-1">
+    <main className="flex h-full flex-1 bg-transparent">
       <ResizablePanelGroup direction="horizontal" className="h-full w-full">
         <ResizablePanel
           defaultSize={25}
           minSize={20}
-          className="hidden border-r md:block"
+          className="hidden border-r border-white/10 md:block"
         >
           <ConversationList />
         </ResizablePanel>
         <ResizableHandle className="hidden md:block" />
         <ResizablePanel defaultSize={75} minSize={50}>
           <div className="flex h-full flex-col">
-            <header className="flex items-center justify-between border-b px-6 py-4">
-              <div>
-                <h1 className="text-lg font-semibold">
+            <header className="flex items-center justify-between border-b border-white/10 bg-white/50 px-6 py-4 backdrop-blur dark:bg-white/[0.04]">
+              <div className="space-y-1">
+                <h1 className="text-lg font-semibold text-[var(--text)]">
                   {process.env.NEXT_PUBLIC_APP_NAME ?? 'Explorer Agent'}
                 </h1>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-sm text-[var(--muted)]">
                   Webhook-powered conversations
                 </p>
               </div>
-              <a
-                href="/settings"
-                className="text-sm font-medium text-primary underline-offset-4 hover:underline"
-                aria-label="Open settings"
-              >
-                Settings
-              </a>
+              <div className="flex items-center gap-3">
+                <a
+                  href="/settings"
+                  className="text-sm font-medium text-[var(--text)]/80 underline-offset-4 transition hover:text-[var(--text)] hover:underline dark:text-white/80"
+                  aria-label="Open settings"
+                >
+                  Settings
+                </a>
+                <div className="md:hidden">
+                  <ThemeToggle />
+                </div>
+              </div>
             </header>
-            <div className="md:hidden border-b">
+            <div className="border-b border-white/10 md:hidden">
               <ConversationList enableShortcuts={false} />
             </div>
             <ChatWindow />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -17,9 +17,9 @@ interface HeaderRow {
 }
 
 interface HealthResponse {
-  allowlist: string[];
   status: 'ok' | 'error';
   message?: string;
+  defaultWebhook?: string;
 }
 
 export default function SettingsPage() {
@@ -35,17 +35,17 @@ export default function SettingsPage() {
   const [headers, setHeaders] = React.useState<HeaderRow[]>(() =>
     Object.entries(extraHeaders ?? {}).map(([key, value]) => ({ key, value })),
   );
-  const [allowlist, setAllowlist] = React.useState<string[]>([]);
   const [status, setStatus] = React.useState<'ok' | 'error'>('ok');
   const [message, setMessage] = React.useState<string | undefined>();
+  const [defaultWebhook, setDefaultWebhook] = React.useState<string | undefined>();
 
   React.useEffect(() => {
     fetch('/api/health')
       .then((response) => response.json())
       .then((data: HealthResponse) => {
-        setAllowlist(data.allowlist);
         setStatus(data.status);
         setMessage(data.message);
+        setDefaultWebhook(data.defaultWebhook);
       })
       .catch(() => {
         setStatus('error');
@@ -88,18 +88,19 @@ export default function SettingsPage() {
     setWebhookUrl(event.target.value);
   };
 
-  const isAllowed = React.useMemo(() => {
+  const isValidWebhook = React.useMemo(() => {
     if (!webhookUrl) {
       return true;
     }
     try {
-      const host = new URL(webhookUrl).host.toLowerCase();
-      return allowlist.includes(host);
+      // Ensure the URL parses correctly; we allow any valid host.
+      new URL(webhookUrl);
+      return true;
     } catch (error) {
       console.warn('Invalid webhook URL provided', error);
       return false;
     }
-  }, [allowlist, webhookUrl]);
+  }, [webhookUrl]);
 
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-6">
@@ -117,7 +118,7 @@ export default function SettingsPage() {
           Back to chat
         </Link>
       </div>
-      <div className="space-y-4 rounded-lg border p-6">
+      <div className="space-y-4 rounded-2xl border border-black/10 bg-white/80 p-6 shadow-soft dark:border-white/10 dark:bg-white/[0.04]">
         <div className="space-y-2">
           <Label htmlFor="webhook">Webhook URL</Label>
           <Input
@@ -125,15 +126,20 @@ export default function SettingsPage() {
             value={webhookUrl}
             onChange={handleWebhookChange}
             placeholder="https://hooks.n8n.cloud/..."
-            aria-invalid={!isAllowed}
+            aria-invalid={!isValidWebhook}
           />
-          <p className="text-xs text-muted-foreground">
-            Allowed domains:{' '}
-            {allowlist.length > 0 ? allowlist.join(', ') : 'loading...'}
+          <p className="text-xs text-[var(--muted)]">
+            Provide any valid HTTPS endpoint. The proxy will validate the URL
+            before forwarding requests.
           </p>
-          {!isAllowed ? (
+          {!isValidWebhook ? (
             <p className="text-xs text-destructive">
-              Webhook must match an allowed domain.
+              Enter a valid webhook URL (including protocol).
+            </p>
+          ) : null}
+          {defaultWebhook ? (
+            <p className="text-xs text-[var(--muted)]">
+              Default webhook: <span className="font-medium">{defaultWebhook}</span>
             </p>
           ) : null}
         </div>
@@ -152,7 +158,7 @@ export default function SettingsPage() {
           />
         </div>
       </div>
-      <div className="space-y-4 rounded-lg border p-6">
+      <div className="space-y-4 rounded-2xl border border-black/10 bg-white/80 p-6 shadow-soft dark:border-white/10 dark:bg-white/[0.04]">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold">Extra headers</h2>
           <Button type="button" variant="outline" onClick={handleAddHeader}>
@@ -168,7 +174,7 @@ export default function SettingsPage() {
           {headers.map((header, index) => (
             <div
               key={index}
-              className="flex flex-col gap-2 rounded-md border p-3 sm:flex-row sm:items-center"
+              className="flex flex-col gap-2 rounded-2xl border border-black/10 bg-white/70 p-3 shadow-sm sm:flex-row sm:items-center dark:border-white/10 dark:bg-white/[0.05]"
             >
               <Input
                 value={header.key}
@@ -200,7 +206,7 @@ export default function SettingsPage() {
           Save headers
         </Button>
       </div>
-      <div className="rounded-lg border p-6 text-sm">
+      <div className="rounded-2xl border border-black/10 bg-white/80 p-6 text-sm shadow-soft dark:border-white/10 dark:bg-white/[0.04]">
         <h2 className="mb-2 text-lg font-semibold">System status</h2>
         <p className="text-muted-foreground">
           Status:{' '}

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -259,8 +259,8 @@ export function ChatWindow() {
 
   return (
     <div className="flex h-full flex-1 flex-col">
-      <ScrollArea className="flex-1 p-4">
-        <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+      <ScrollArea className="flex-1 px-6 py-6">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
           {activeMessages.map((message) => (
             <MessageBubble key={message.id} message={message} />
           ))}

--- a/components/chat/Composer.tsx
+++ b/components/chat/Composer.tsx
@@ -149,16 +149,18 @@ export function Composer({
   );
 
   return (
-    <div className="space-y-2 border-t bg-background p-4">
-      <Textarea
-        value={message}
-        onChange={(event) => setMessage(event.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder="Type your message..."
-        aria-label="Message"
-        disabled={Boolean(disabled || isStreaming)}
-      />
-      <div className="flex flex-wrap items-center justify-between gap-2">
+    <div className="border-t border-white/5 bg-transparent p-4 dark:border-white/10">
+      <div className="rounded-2xl border border-black/10 bg-white/70 p-4 shadow-pill focus-within:ring-2 focus-within:[--tw-ring-color:var(--ring)] dark:border-white/10 dark:bg-white/[0.04]">
+        <Textarea
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type your message..."
+          aria-label="Message"
+          disabled={Boolean(disabled || isStreaming)}
+          className="min-h-[120px] rounded-2xl border-none bg-transparent text-[var(--text)] placeholder:text-[var(--muted)] focus-visible:ring-0"
+        />
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Button
             type="button"
@@ -223,6 +225,7 @@ export function Composer({
             )}{' '}
             Send
           </Button>
+        </div>
         </div>
       </div>
     </div>

--- a/components/chat/MessageBubble.tsx
+++ b/components/chat/MessageBubble.tsx
@@ -5,9 +5,6 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ClipboardCopy } from 'lucide-react';
 
-import { Card } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import type { ChatMessage } from '@/lib/types';
 import { cn } from '@/lib/utils';
@@ -28,38 +25,77 @@ export function MessageBubble({ message }: MessageBubbleProps) {
     }
   };
 
-  const roleVariant = message.role === 'assistant' ? 'default' : 'secondary';
+  const isAssistant = message.role === 'assistant';
   const formattedTime = new Date(message.createdAt).toLocaleTimeString([], {
     hour: '2-digit',
     minute: '2-digit',
   });
 
   return (
-    <Card
+    <div
       className={cn(
-        'p-4',
-        message.role === 'assistant' ? 'bg-muted/50' : 'bg-background',
+        'flex w-full',
+        isAssistant ? 'justify-start' : 'justify-end',
       )}
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Badge variant={roleVariant}>{message.role}</Badge>
-          <span className="text-xs text-muted-foreground">{formattedTime}</span>
-        </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => void handleCopy()}
-          aria-label="Copy message"
+      <div
+        className={cn(
+          'w-full max-w-3xl space-y-3',
+          isAssistant ? 'text-[var(--text)]' : 'text-white',
+        )}
+      >
+        <div
+          className={cn(
+            'rounded-2xl p-4 shadow-sm transition',
+            isAssistant
+              ? 'border border-white/10 bg-white/[0.03]'
+              : 'aiti-gradient text-white shadow',
+          )}
         >
-          <ClipboardCopy className="h-4 w-4" />
-        </Button>
+          <div className="flex items-center justify-between text-xs uppercase tracking-wide">
+            <div
+              className={cn(
+                'font-semibold',
+                isAssistant
+                  ? 'text-[var(--text)]/70 dark:text-white/70'
+                  : 'text-white/80',
+              )}
+            >
+              {isAssistant ? 'Assistant' : 'You'}
+            </div>
+            <div className="flex items-center gap-2">
+              <span
+                className={cn(
+                  'text-xs',
+                  isAssistant
+                    ? 'text-[var(--muted)] dark:text-white/60'
+                    : 'text-white/80',
+                )}
+              >
+                {formattedTime}
+              </span>
+              <button
+                type="button"
+                onClick={() => void handleCopy()}
+                aria-label="Copy message"
+                className={cn(
+                  'flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-current/70 transition hover:opacity-80 focus:outline-none focus-visible:ring-2',
+                  isAssistant
+                    ? 'border-white/10 text-[var(--text)]/60 dark:text-white/70'
+                    : 'border-white/20 text-white/80',
+                )}
+              >
+                <ClipboardCopy className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+          <div className="prose prose-sm mt-3 max-w-none dark:prose-invert">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {message.content}
+            </ReactMarkdown>
+          </div>
+        </div>
       </div>
-      <div className="prose prose-sm mt-3 max-w-none dark:prose-invert">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-          {message.content}
-        </ReactMarkdown>
-      </div>
-    </Card>
+    </div>
   );
 }

--- a/components/sidebar/ConversationList.tsx
+++ b/components/sidebar/ConversationList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import Image from 'next/image';
 import { MoreHorizontal, Plus, Upload, Download, Search } from 'lucide-react';
 
 import { useChatStore } from '@/lib/state';
@@ -23,6 +24,8 @@ import {
 } from '@/components/ui/command';
 import { useToast } from '@/components/ui/use-toast';
 import type { ConversationSummary } from '@/lib/types';
+import ThemeToggle from '@/components/ui/ThemeToggle';
+import { cn } from '@/lib/utils';
 
 interface ConversationListProps {
   onConversationSelected?: (id: string) => void;
@@ -149,60 +152,73 @@ export function ConversationList({
   };
 
   return (
-    <div className="flex h-full flex-col gap-4 p-4">
-      <div className="flex items-center gap-2">
-        <Button
-          className="flex-1"
-          onClick={() => void handleCreate()}
-          aria-label="New conversation"
-        >
-          <Plus className="mr-2 h-4 w-4" /> New
-        </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => void handleExport()}
-          aria-label="Export conversations"
-        >
-          <Download className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => fileInputRef.current?.click()}
-          aria-label="Import conversations"
-        >
-          <Upload className="h-4 w-4" />
-        </Button>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="application/json"
-          className="hidden"
-          onChange={handleImport}
-          aria-hidden
-        />
-      </div>
-      <Button
-        variant="secondary"
-        className="justify-start"
-        onClick={() => setCommandOpen(true)}
-        aria-label="Search conversations"
-      >
-        <Search className="mr-2 h-4 w-4" /> Search (Ctrl/Cmd + K)
-      </Button>
-      <ScrollArea className="flex-1">
-        <div className="space-y-1">
+    <div className="h-full p-4">
+      <div className="flex h-full flex-col gap-4 rounded-2xl border border-black/5 bg-white/80 p-4 shadow-soft backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.04]">
+        <div className="flex items-center justify-between rounded-2xl border border-black/5 bg-black/5 px-3 py-2 text-sm text-[var(--text)]/80 dark:border-white/10 dark:bg-white/[0.08] dark:text-white/80">
+          <div className="flex items-center gap-2">
+            <Image src="/favicon.svg" alt="AITI" width={24} height={24} className="h-6 w-6" />
+            <span className="font-medium">AI Training Institute</span>
+          </div>
+          <ThemeToggle />
+        </div>
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={() => void handleCreate()}
+            aria-label="New conversation"
+            className="aiti-gradient flex items-center justify-center gap-2 rounded-2xl px-4 py-2 text-sm font-medium text-white shadow-soft transition hover:opacity-90 focus:outline-none focus-visible:ring-2"
+          >
+            <Plus className="h-4 w-4" /> Neu
+          </button>
+          <div className="flex items-center justify-between gap-2">
+            <button
+              type="button"
+              onClick={() => void handleExport()}
+              aria-label="Export conversations"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-black/10 text-[var(--text)]/70 transition hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 dark:border-white/10 dark:text-white/70 dark:hover:text-white"
+            >
+              <Download className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              aria-label="Import conversations"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-black/10 text-[var(--text)]/70 transition hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 dark:border-white/10 dark:text-white/70 dark:hover:text-white"
+            >
+              <Upload className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setCommandOpen(true)}
+              aria-label="Search conversations"
+              className="surface flex flex-1 items-center gap-2 rounded-2xl border border-black/10 px-3 py-2 text-sm text-[var(--text)]/70 transition hover:border-black/20 hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
+            >
+              <Search className="h-4 w-4" /> Suche (Ctrl/Cmd + K)
+            </button>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json"
+            className="hidden"
+            onChange={handleImport}
+            aria-hidden
+          />
+        </div>
+        <ScrollArea className="flex-1">
+          <div className="space-y-2">
           {conversations.map((conversation) => {
             const isActive = conversation.id === activeConversationId;
             const isEditing = editingId === conversation.id;
             return (
               <div
                 key={conversation.id}
-                className={
-                  'group flex items-center justify-between rounded-md border border-transparent px-2 py-1.5 text-sm transition-colors hover:bg-accent hover:text-accent-foreground' +
-                  (isActive ? ' bg-accent text-accent-foreground' : '')
-                }
+                className={cn(
+                  'group flex items-center justify-between gap-2 rounded-2xl px-3 py-2 text-sm transition',
+                  isActive
+                    ? 'aiti-gradient text-white shadow'
+                    : 'border border-black/10 bg-white/70 text-[var(--text)]/80 hover:border-black/20 hover:text-[var(--text)] dark:border-white/10 dark:bg-white/[0.03] dark:text-white/70 dark:hover:bg-white/[0.08] dark:hover:text-white',
+                )}
               >
                 {isEditing ? (
                   <form
@@ -216,17 +232,21 @@ export function ConversationList({
                       value={newTitle}
                       onChange={(event) => setNewTitle(event.target.value)}
                       autoFocus
-                      className="h-8"
+                      className="h-9 rounded-2xl border-black/10 bg-white/80 text-sm text-[var(--text)] focus-visible:ring-2 dark:border-white/10 dark:bg-white/[0.05] dark:text-white"
                     />
-                    <Button type="submit" size="sm" variant="secondary">
-                      Save
+                    <Button
+                      type="submit"
+                      size="sm"
+                      className="aiti-gradient rounded-2xl px-3 py-2 text-xs text-white shadow-soft hover:opacity-90"
+                    >
+                      Speichern
                     </Button>
                   </form>
                 ) : (
                   <button
                     type="button"
                     onClick={() => void handleSelect(conversation)}
-                    className="flex flex-1 items-center gap-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    className="flex flex-1 items-center gap-2 text-left font-medium text-current outline-none focus-visible:ring-2"
                   >
                     <span
                       className="flex-1 truncate"
@@ -238,13 +258,13 @@ export function ConversationList({
                 )}
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
+                    <button
+                      type="button"
                       aria-label="Conversation options"
+                      className="flex h-8 w-8 items-center justify-center rounded-full border border-transparent text-current/80 transition hover:text-current focus:outline-none focus-visible:ring-2"
                     >
                       <MoreHorizontal className="h-4 w-4" />
-                    </Button>
+                    </button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuItem
@@ -288,5 +308,6 @@ export function ConversationList({
         </CommandList>
       </CommandDialog>
     </div>
+  </div>
   );
 }

--- a/components/ui/ThemeToggle.tsx
+++ b/components/ui/ThemeToggle.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { Moon, Sun } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+export default function ThemeToggle() {
+  const { setTheme, resolvedTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
+
+  if (!mounted) return null
+
+  const isDark = resolvedTheme === 'dark'
+  return (
+    <button
+      aria-label="Theme umschalten"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white shadow-soft transition hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] dark:bg-white/5 dark:text-white"
+    >
+      {isDark ? <Sun size={16} /> : <Moon size={16} />}
+      {isDark ? 'Light' : 'Dark'}
+    </button>
+  )
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -7,24 +7,25 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-2xl text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default: 'aiti-gradient text-white shadow-soft hover:opacity-95',
         secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+          'surface border border-black/10 text-[var(--text)]/80 shadow-soft hover:border-black/20 hover:text-[var(--text)] dark:border-white/10 dark:hover:border-white/20 dark:text-white/80',
         outline:
-          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
+          'border border-black/10 bg-transparent text-[var(--text)]/80 shadow-sm hover:border-black/20 hover:bg-black/5 hover:text-[var(--text)] dark:border-white/20 dark:bg-transparent dark:text-white/80 dark:hover:bg-white/[0.08] dark:hover:text-white',
+        ghost:
+          'text-[var(--text)]/70 hover:bg-black/5 hover:text-[var(--text)] dark:text-white/70 dark:hover:bg-white/[0.08] dark:hover:text-white',
         destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        link: 'text-primary underline-offset-4 hover:underline',
+          'bg-accent-red text-white shadow-soft hover:brightness-110 focus-visible:[--tw-ring-color:rgba(255,69,58,0.6)]',
+        link: 'text-[var(--text)] underline-offset-4 hover:underline dark:text-white',
       },
       size: {
-        default: 'h-10 px-4 py-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
+        default: 'h-11 px-5',
+        sm: 'h-9 px-4 text-sm',
+        lg: 'h-12 px-8 text-base',
         icon: 'h-10 w-10',
       },
     },

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -34,13 +34,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl border border-black/10 bg-white/80 p-6 shadow-soft backdrop-blur duration-200 dark:border-white/10 dark:bg-white/[0.06] data-[state=open]:animate-in data-[state=closed]:animate-out',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full border border-transparent bg-black/5 p-2 text-[var(--text)]/70 opacity-80 transition hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] dark:bg-white/[0.08] dark:text-white/70">
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-11 w-full rounded-2xl border border-black/10 bg-white/80 px-3 py-2 text-sm text-[var(--text)] shadow-sm transition file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-white/[0.05] dark:text-white',
           className,
         )}
         ref={ref}

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -12,12 +12,12 @@ const Switch = React.forwardRef<
   <SwitchPrimitives.Root
     ref={ref}
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'peer inline-flex h-7 w-12 shrink-0 cursor-pointer items-center rounded-full border border-black/10 bg-black/10 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-aiti-gold-500 data-[state=unchecked]:bg-black/20 dark:border-white/15 dark:bg-white/[0.05] dark:data-[state=unchecked]:bg-white/[0.08]',
       className,
     )}
     {...props}
   >
-    <SwitchPrimitives.Thumb className="pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0" />
+    <SwitchPrimitives.Thumb className="pointer-events-none block h-5 w-5 rounded-full bg-white shadow-soft ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 dark:bg-[var(--surface)]" />
   </SwitchPrimitives.Root>
 ));
 Switch.displayName = SwitchPrimitives.Root.displayName;

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex min-h-[120px] w-full rounded-2xl border border-black/10 bg-white/80 px-3 py-2 text-sm text-[var(--text)] shadow-sm transition placeholder:text-[var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-white/[0.05] dark:text-white',
           className,
         )}
         ref={ref}

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -24,13 +24,13 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitive.Viewport.displayName;
 
 const toastVariants = cva(
-  'group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border bg-background p-4 text-sm shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:zoom-out-95 data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full sm:max-w-sm',
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-3 overflow-hidden rounded-2xl border border-black/10 bg-white/80 p-4 text-sm text-[var(--text)] shadow-soft backdrop-blur transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:zoom-out-95 data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full sm:max-w-sm dark:border-white/10 dark:bg-white/[0.08] dark:text-white',
   {
     variants: {
       variant: {
-        default: 'border border-border bg-background text-foreground',
+        default: '',
         destructive:
-          'group border-destructive bg-destructive text-destructive-foreground',
+          'group border-transparent bg-accent-red text-white shadow-soft',
       },
     },
     defaultVariants: {
@@ -61,7 +61,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitive.Action
     ref={ref}
     className={cn(
-      'inline-flex h-8 items-center justify-center rounded-md border px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+      'inline-flex h-9 items-center justify-center rounded-2xl border border-black/10 px-3 text-sm font-medium text-[var(--text)]/80 transition hover:border-black/20 hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] dark:border-white/15 dark:text-white/80 dark:hover:border-white/25 dark:hover:text-white',
       className,
     )}
     {...props}
@@ -76,7 +76,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitive.Close
     ref={ref}
     className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-foreground/80 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+      'absolute right-2 top-2 rounded-full border border-transparent p-2 text-[var(--text)]/60 transition hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] dark:text-white/60',
       className,
     )}
     toast-close=""

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1,9 +1,3 @@
-const RAW_ALLOWLIST = process.env.WEBHOOK_ALLOWLIST ?? '';
-
-const ALLOWLIST = RAW_ALLOWLIST.split(',')
-  .map((entry) => entry.trim().toLowerCase())
-  .filter(Boolean);
-
 const SAFE_HEADER_SET = new Set([
   'x-api-key',
   'x-workflow-id',
@@ -20,10 +14,6 @@ const BLOCKED_HEADERS = new Set([
   'connection',
 ]);
 
-export function getAllowlist(): string[] {
-  return [...ALLOWLIST];
-}
-
 export function getDefaultWebhook(): string | undefined {
   return process.env.N8N_DEFAULT_WEBHOOK_URL?.trim();
 }
@@ -35,27 +25,16 @@ export function sanitizeInput(value: unknown): string {
   return value.replace(/[^\t\n\r\x20-\x7E]/g, '').trim();
 }
 
-export function isUrlAllowed(url: string | undefined | null): boolean {
-  if (!url) {
-    return false;
-  }
-  try {
-    const parsed = new URL(url);
-    return ALLOWLIST.includes(parsed.host.toLowerCase());
-  } catch (error) {
-    console.warn('Invalid URL when checking allowlist', error);
-    return false;
-  }
-}
-
 export function assertAllowedUrl(url: string | undefined | null): string {
   if (!url) {
     throw new Error('Webhook URL is required');
   }
-  if (!isUrlAllowed(url)) {
-    throw new Error('Webhook URL is not in the allowlist');
+  try {
+    const parsed = new URL(url);
+    return parsed.toString();
+  } catch {
+    throw new Error('Invalid webhook URL');
   }
-  return url;
 }
 
 export function filterExtraHeaders(

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "idb-keyval": "^6.2.2",
         "lucide-react": "^0.544.0",
         "next": "^14.2.32",
+        "next-themes": "^0.4.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -6508,6 +6509,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "idb-keyval": "^6.2.2",
     "lucide-react": "^0.544.0",
     "next": "^14.2.32",
+    "next-themes": "^0.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,7 +4,7 @@ import defaultTheme from 'tailwindcss/defaultTheme';
 import tailwindcssAnimate from 'tailwindcss-animate';
 
 const config: Config = {
-  darkMode: 'class',
+  darkMode: ['class'] as unknown as Config['darkMode'],
   content: [
     './app/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
@@ -15,7 +15,7 @@ const config: Config = {
       colors: {
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
+        ring: 'hsl(var(--ring-hsl))',
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
         primary: {
@@ -37,6 +37,10 @@ const config: Config = {
         accent: {
           DEFAULT: 'hsl(var(--accent))',
           foreground: 'hsl(var(--accent-foreground))',
+          blue: '#0A84FF',
+          green: '#34C759',
+          orange: '#FF9F0A',
+          red: '#FF453A',
         },
         popover: {
           DEFAULT: 'hsl(var(--popover))',
@@ -46,14 +50,39 @@ const config: Config = {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        aiti: {
+          gold: {
+            50: '#FFF8D6',
+            100: '#F9E33C',
+            200: '#F7E433',
+            300: '#F5CD39',
+            400: '#F9BE3B',
+            500: '#ECAF3B',
+            600: '#C59C3E',
+          },
+        },
+        neu: {
+          0: '#FFFFFF',
+          50: '#F6F7F8',
+          100: '#EEF0F2',
+          200: '#E4E7EB',
+          700: '#2C2F33',
+          800: '#1F2226',
+          900: '#121418',
+        },
       },
       borderRadius: {
+        '2xl': '1.25rem',
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
       },
       fontFamily: {
         sans: ['var(--font-sans)', ...defaultTheme.fontFamily.sans],
+      },
+      boxShadow: {
+        soft: '0 2px 20px rgba(0,0,0,0.25)',
+        pill: '0 1px 12px rgba(0,0,0,0.35)',
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## Summary
- apply the new AITI color tokens, global CSS variables, and Tailwind configuration to support a dark-first experience with optional light mode
- add a next-themes powered ThemeProvider plus a reusable theme toggle that updates the layout, sidebar, chat window, and shared UI components
- remove the webhook allow list enforcement and refresh settings, proxy validation, and docs to reflect the new open URL policy

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cd346ece3883248398b9e25a817560