### PR TITLE
Handle plain text webhook responses and fix hydration

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -6,22 +6,35 @@ export const runtime = 'nodejs';
 
 export function GET() {
   const defaultWebhook = getDefaultWebhook();
-  const missing: string[] = [];
+  const defaultsApplied: string[] = [];
 
-  if (!process.env.MAX_REQUEST_BYTES) {
-    missing.push('MAX_REQUEST_BYTES');
-  }
-  if (!process.env.REQUEST_TIMEOUT_MS) {
-    missing.push('REQUEST_TIMEOUT_MS');
-  }
+  const maxRequestBytes = process.env.MAX_REQUEST_BYTES
+    ? Number(process.env.MAX_REQUEST_BYTES)
+    : (() => {
+        defaultsApplied.push('MAX_REQUEST_BYTES');
+        return 5_000_000;
+      })();
+  const requestTimeoutMs = process.env.REQUEST_TIMEOUT_MS
+    ? Number(process.env.REQUEST_TIMEOUT_MS)
+    : (() => {
+        defaultsApplied.push('REQUEST_TIMEOUT_MS');
+        return 30_000;
+      })();
 
-  const status = missing.length === 0 ? 'ok' : 'error';
+  const status = 'ok';
   const message =
-    missing.length === 0
+    defaultsApplied.length === 0
       ? defaultWebhook
         ? `Default webhook configured: ${defaultWebhook}`
         : 'Ready to accept requests.'
-      : `Missing configuration: ${missing.join(', ')}`;
+      : `Using default configuration for: ${defaultsApplied.join(', ')}`;
 
-  return NextResponse.json({ status, message, defaultWebhook });
+  return NextResponse.json({
+    status,
+    message,
+    defaultWebhook,
+    maxRequestBytes,
+    requestTimeoutMs,
+    defaultsApplied,
+  });
 }

--- a/components/chat/Composer.tsx
+++ b/components/chat/Composer.tsx
@@ -44,7 +44,11 @@ export function Composer({
   const audioChunksRef = React.useRef<Blob[]>([]);
   const audioElementRef = React.useRef<HTMLAudioElement | null>(null);
 
-  const canRecord = React.useMemo(() => isRecordingSupported(), []);
+  const [canRecord, setCanRecord] = React.useState(false);
+
+  React.useEffect(() => {
+    setCanRecord(isRecordingSupported());
+  }, []);
 
   React.useEffect(() => {
     return () => {

--- a/types/next-themes.d.ts
+++ b/types/next-themes.d.ts
@@ -1,0 +1,27 @@
+declare module 'next-themes' {
+  import * as React from 'react';
+
+  export interface ThemeProviderProps {
+    attribute?: string;
+    defaultTheme?: string;
+    enableSystem?: boolean;
+    forcedTheme?: string;
+    storageKey?: string;
+    value?: string;
+    themes?: string[];
+    disableTransitionOnChange?: boolean;
+    children?: React.ReactNode;
+  }
+
+  export const ThemeProvider: React.ComponentType<ThemeProviderProps>;
+
+  export interface UseThemeReturn {
+    theme?: string;
+    setTheme: (theme: string) => void;
+    resolvedTheme?: string;
+    systemTheme?: string;
+    forcedTheme?: string;
+  }
+
+  export function useTheme(): UseThemeReturn;
+}


### PR DESCRIPTION
## Summary
- allow the chat proxy to forward plain text webhook responses alongside JSON
- update the health endpoint to report default limits instead of erroring when env vars are missing
- fix the composer hydration warning by deferring recording capability detection and add types for next-themes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd5470499883249a149d3269250dc1