### PR TITLE
style: redesign interface with glassmorphism

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,71 +3,106 @@
 @tailwind utilities;
 
 :root {
-  /* Light (nur wenn .light auf <html>) */
-  --bg: #ffffff;
-  --surface: #f6f7f8;
-  --text: #0b0c0e;
-  --muted: #6b7177;
-  --ring: rgba(10, 132, 255, 0.35);
-  --grad-from: #f7e433; /* aiti-gold-200 */
-  --grad-to: #ecaf3b; /* aiti-gold-500 */
+  --font-sans: 'SF Pro Text', 'SF Pro Display', 'Inter', 'Helvetica Neue',
+    system-ui, -apple-system, sans-serif;
+  --bg: #f4f6fb;
+  --surface: rgba(255, 255, 255, 0.55);
+  --surface-strong: rgba(255, 255, 255, 0.78);
+  --text: #05060a;
+  --muted: #7b8494;
+  --ring: rgba(10, 132, 255, 0.28);
+  --grad-from: #0a84ff;
+  --grad-to: #5ac8fa;
+  --glass-border: rgba(255, 255, 255, 0.55);
+  --glass-bg: rgba(255, 255, 255, 0.68);
+  --glass-overlay: rgba(255, 255, 255, 0.45);
+  --glass-shadow: 0 24px 60px -25px rgba(37, 56, 118, 0.25);
+  --app-gradient: radial-gradient(
+      circle at 12% 18%,
+      rgba(10, 132, 255, 0.35),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at 90% 8%,
+      rgba(255, 255, 255, 0.55),
+      transparent 45%
+    ),
+    linear-gradient(180deg, #f4f6fb 0%, #eef1f8 55%, #f9fafc 100%);
 
-  --background: 0 0% 100%;
-  --foreground: 220 14% 6%;
+  --background: 218 60% 97%;
+  --foreground: 222 32% 14%;
   --card: 0 0% 100%;
-  --card-foreground: 220 14% 6%;
+  --card-foreground: 222 32% 14%;
   --popover: 0 0% 100%;
-  --popover-foreground: 220 14% 6%;
-  --primary: 40 92% 56%;
-  --primary-foreground: 220 14% 12%;
-  --secondary: 210 25% 92%;
-  --secondary-foreground: 220 18% 18%;
-  --muted-foreground: 215 15% 46%;
+  --popover-foreground: 222 32% 14%;
+  --primary: 216 100% 64%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 210 37% 94%;
+  --secondary-foreground: 222 28% 20%;
+  --muted-foreground: 215 18% 42%;
   --accent: 216 100% 64%;
   --accent-foreground: 0 0% 100%;
   --destructive: 0 84% 60%;
   --destructive-foreground: 0 0% 100%;
-  --border: 210 25% 90%;
-  --input: 210 25% 90%;
+  --border: 210 31% 88%;
+  --input: 210 31% 88%;
   --ring-hsl: 216 100% 64%;
-  --radius: 1rem;
+  --radius: 1.4rem;
 
   color-scheme: light;
 }
 
 .dark {
-  --bg: #121418; /* neu-900 */
-  --surface: #16181c; /* dunkle Fläche */
-  --text: #f7f8fa;
-  --muted: #9aa1a9;
-  --ring: rgba(10, 132, 255, 0.5);
-  --grad-from: #f5cd39; /* aiti-gold-300 */
-  --grad-to: #c59c3e; /* aiti-gold-600 */
+  --font-sans: 'SF Pro Text', 'SF Pro Display', 'Inter', 'Helvetica Neue',
+    system-ui, -apple-system, sans-serif;
+  --bg: #05070f;
+  --surface: rgba(12, 16, 27, 0.55);
+  --surface-strong: rgba(12, 16, 27, 0.74);
+  --text: #f5f7ff;
+  --muted: #9ba5bb;
+  --ring: rgba(10, 132, 255, 0.4);
+  --grad-from: #0a84ff;
+  --grad-to: #64d2ff;
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-bg: rgba(7, 11, 20, 0.72);
+  --glass-overlay: rgba(22, 30, 43, 0.62);
+  --glass-shadow: 0 30px 70px -35px rgba(0, 0, 0, 0.8);
+  --app-gradient: radial-gradient(
+      circle at 15% 18%,
+      rgba(10, 132, 255, 0.42),
+      transparent 52%
+    ),
+    radial-gradient(
+      circle at 80% 0%,
+      rgba(100, 210, 255, 0.22),
+      transparent 45%
+    ),
+    linear-gradient(180deg, #03050c 0%, #070b16 60%, #0b1020 100%);
 
-  --background: 220 18% 8%;
-  --foreground: 215 20% 96%;
-  --card: 220 20% 11%;
-  --card-foreground: 215 20% 96%;
-  --popover: 220 20% 11%;
-  --popover-foreground: 215 20% 96%;
-  --primary: 40 92% 56%;
-  --primary-foreground: 216 28% 12%;
-  --secondary: 220 19% 20%;
-  --secondary-foreground: 215 20% 92%;
-  --muted-foreground: 214 18% 74%;
+  --background: 220 40% 7%;
+  --foreground: 214 88% 97%;
+  --card: 220 40% 11%;
+  --card-foreground: 214 88% 97%;
+  --popover: 220 40% 11%;
+  --popover-foreground: 214 88% 97%;
+  --primary: 216 100% 64%;
+  --primary-foreground: 214 88% 97%;
+  --secondary: 220 35% 20%;
+  --secondary-foreground: 214 70% 94%;
+  --muted-foreground: 215 18% 70%;
   --accent: 216 100% 64%;
-  --accent-foreground: 215 20% 96%;
+  --accent-foreground: 214 88% 97%;
   --destructive: 0 84% 60%;
-  --destructive-foreground: 215 20% 96%;
-  --border: 215 19% 24%;
-  --input: 215 19% 24%;
+  --destructive-foreground: 214 88% 97%;
+  --border: 218 28% 22%;
+  --input: 218 28% 22%;
   --ring-hsl: 216 100% 64%;
 
   color-scheme: dark;
 }
 
 * {
-  @apply border-border;
+  border-color: hsl(var(--border));
 }
 
 html,
@@ -78,7 +113,24 @@ body {
 }
 
 body {
-  @apply font-sans antialiased;
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  background: var(--app-gradient);
+  position: relative;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(
+      circle at 10% 90%,
+      rgba(90, 200, 250, 0.22),
+      transparent 35%
+    )
+    no-repeat;
+  pointer-events: none;
+  z-index: -1;
 }
 
 #__next {
@@ -86,7 +138,8 @@ body {
 }
 
 .aiti-gradient {
-  background: linear-gradient(135deg, var(--grad-from), var(--grad-to));
+  background: linear-gradient(120deg, var(--grad-from), var(--grad-to));
+  box-shadow: 0 18px 36px -22px rgba(10, 132, 255, 0.55);
 }
 
 .surface {
@@ -96,4 +149,46 @@ body {
 .focus-ring {
   @apply focus-visible:outline-none focus-visible:ring-2;
   box-shadow: 0 0 0 2px var(--ring);
+}
+
+.glass-panel {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+}
+
+.glass-toolbar {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.92),
+    rgba(255, 255, 255, 0.7)
+  );
+  border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.35) inset;
+}
+
+.dark .glass-toolbar {
+  background: linear-gradient(
+    135deg,
+    rgba(24, 30, 45, 0.9),
+    rgba(14, 18, 28, 0.78)
+  );
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05) inset;
+}
+
+.glass-button {
+  background: var(--glass-overlay);
+  border: 1px solid var(--glass-border);
+  box-shadow: 0 16px 32px -20px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+}
+
+.dark .glass-button {
+  background: rgba(18, 26, 39, 0.6);
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 36px -24px rgba(0, 0, 0, 0.85);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <div className="flex min-h-screen flex-col bg-[var(--bg)] text-[var(--text)]">
+          <div className="flex min-h-screen flex-col bg-transparent text-[var(--text)]">
             {children}
           </div>
           <Toaster />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,50 +6,66 @@ import {
   ResizableHandle,
 } from '@/components/ui/resizable';
 import ThemeToggle from '@/components/ui/ThemeToggle';
+import { Button } from '@/components/ui/button';
 
 export default function HomePage() {
   return (
-    <main className="flex h-full flex-1 bg-transparent">
-      <ResizablePanelGroup direction="horizontal" className="h-full w-full">
-        <ResizablePanel
-          defaultSize={25}
-          minSize={20}
-          className="hidden border-r border-white/10 md:block"
-        >
-          <ConversationList />
-        </ResizablePanel>
-        <ResizableHandle className="hidden md:block" />
-        <ResizablePanel defaultSize={75} minSize={50}>
-          <div className="flex h-full flex-col">
-            <header className="flex items-center justify-between border-b border-white/10 bg-white/50 px-6 py-4 backdrop-blur dark:bg-white/[0.04]">
-              <div className="space-y-1">
-                <h1 className="text-lg font-semibold text-[var(--text)]">
-                  {process.env.NEXT_PUBLIC_APP_NAME ?? 'Explorer Agent'}
-                </h1>
-                <p className="text-sm text-[var(--muted)]">
-                  Webhook-powered conversations
-                </p>
-              </div>
-              <div className="flex items-center gap-3">
-                <a
-                  href="/settings"
-                  className="text-sm font-medium text-[var(--text)]/80 underline-offset-4 transition hover:text-[var(--text)] hover:underline dark:text-white/80"
-                  aria-label="Open settings"
-                >
-                  Settings
-                </a>
-                <div className="md:hidden">
-                  <ThemeToggle />
+    <main className="relative flex min-h-[calc(100vh-4rem)] w-full flex-1 flex-col px-4 py-6 md:px-10 md:py-10">
+      <div className="absolute inset-0 -z-10 mx-auto max-w-7xl overflow-visible">
+        <div className="pointer-events-none absolute inset-0 rounded-[48px] bg-gradient-to-br from-white/20 via-transparent to-white/0 blur-3xl" />
+      </div>
+      <div className="relative mx-auto flex w-full max-w-7xl flex-1">
+        <div className="glass-panel relative flex h-full w-full flex-1 overflow-hidden rounded-[36px] border border-white/60 bg-white/60 shadow-[0_50px_100px_-65px_rgba(15,23,42,0.65)] dark:border-white/10 dark:bg-white/[0.07]">
+          <ResizablePanelGroup direction="horizontal" className="h-full w-full">
+            <ResizablePanel
+              defaultSize={25}
+              minSize={20}
+              className="hidden border-r border-white/50 bg-white/20 backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.04] md:block"
+            >
+              <ConversationList />
+            </ResizablePanel>
+            <ResizableHandle className="hidden bg-white/40 backdrop-blur md:block dark:bg-white/10" />
+            <ResizablePanel defaultSize={75} minSize={50}>
+              <div className="flex h-full flex-col">
+                <header className="glass-toolbar flex items-center justify-between px-8 py-6 text-[var(--text)] dark:text-white">
+                  <div className="space-y-1">
+                    <span className="text-xs font-medium uppercase tracking-[0.4em] text-[var(--muted)] dark:text-white/60">
+                      Explorer Agent
+                    </span>
+                    <h1 className="text-2xl font-semibold text-[var(--text)] dark:text-white">
+                      {process.env.NEXT_PUBLIC_APP_NAME ?? 'Explorer Agent'}
+                    </h1>
+                    <p className="text-sm text-[var(--muted)] dark:text-white/70">
+                      Webhook-powered conversations
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Button
+                      asChild
+                      variant="outline"
+                      size="sm"
+                      className="hidden md:inline-flex"
+                    >
+                      <a href="/settings" aria-label="Open settings">
+                        Einstellungen
+                      </a>
+                    </Button>
+                    <div className="md:hidden">
+                      <ThemeToggle />
+                    </div>
+                  </div>
+                </header>
+                <div className="border-b border-white/40 bg-white/40 px-4 py-3 backdrop-blur md:hidden dark:border-white/10 dark:bg-white/[0.05]">
+                  <ConversationList enableShortcuts={false} />
+                </div>
+                <div className="flex-1 overflow-hidden bg-transparent">
+                  <ChatWindow />
                 </div>
               </div>
-            </header>
-            <div className="border-b border-white/10 md:hidden">
-              <ConversationList enableShortcuts={false} />
-            </div>
-            <ChatWindow />
-          </div>
-        </ResizablePanel>
-      </ResizablePanelGroup>
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        </div>
+      </div>
     </main>
   );
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -105,22 +105,25 @@ export default function SettingsPage() {
   }, [webhookUrl]);
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">Settings</h1>
-          <p className="text-muted-foreground">
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-10 md:px-0">
+      <div className="flex flex-col gap-4 text-[var(--text)] dark:text-white md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2">
+          <span className="text-xs font-medium uppercase tracking-[0.4em] text-[var(--muted)] dark:text-white/60">
+            Einstellungen
+          </span>
+          <h1 className="text-3xl font-semibold">Explorer Agent</h1>
+          <p className="text-sm text-[var(--muted)] dark:text-white/70">
             Configure how Explorer Agent connects to your webhook.
           </p>
         </div>
         <Link
           href="/"
-          className="text-sm text-primary underline-offset-4 hover:underline"
+          className="glass-button inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-medium text-[var(--text)] transition hover:opacity-95 dark:text-white"
         >
           Back to chat
         </Link>
       </div>
-      <div className="space-y-4 rounded-2xl border border-black/10 bg-white/80 p-6 shadow-soft dark:border-white/10 dark:bg-white/[0.04]">
+      <div className="glass-panel space-y-6 rounded-[32px] p-6">
         <div className="space-y-2">
           <Label htmlFor="webhook">Webhook URL</Label>
           <Input
@@ -161,10 +164,17 @@ export default function SettingsPage() {
           />
         </div>
       </div>
-      <div className="space-y-4 rounded-2xl border border-black/10 bg-white/80 p-6 shadow-soft dark:border-white/10 dark:bg-white/[0.04]">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Extra headers</h2>
-          <Button type="button" variant="outline" onClick={handleAddHeader}>
+      <div className="glass-panel space-y-6 rounded-[32px] p-6">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <h2 className="text-lg font-semibold text-[var(--text)] dark:text-white">
+            Extra headers
+          </h2>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleAddHeader}
+            className="rounded-full px-5"
+          >
             Add header
           </Button>
         </div>
@@ -177,7 +187,7 @@ export default function SettingsPage() {
           {headers.map((header, index) => (
             <div
               key={index}
-              className="flex flex-col gap-2 rounded-2xl border border-black/10 bg-white/70 p-3 shadow-sm sm:flex-row sm:items-center dark:border-white/10 dark:bg-white/[0.05]"
+              className="flex flex-col gap-2 rounded-[28px] border border-white/60 bg-white/50 p-4 shadow-soft backdrop-blur sm:flex-row sm:items-center dark:border-white/10 dark:bg-white/[0.05]"
             >
               <Input
                 value={header.key}
@@ -199,18 +209,25 @@ export default function SettingsPage() {
                 type="button"
                 variant="ghost"
                 onClick={() => handleRemoveHeader(index)}
+                className="rounded-full px-4"
               >
                 Remove
               </Button>
             </div>
           ))}
         </div>
-        <Button type="button" onClick={handleSaveHeaders}>
+        <Button
+          type="button"
+          onClick={handleSaveHeaders}
+          className="rounded-full px-6"
+        >
           Save headers
         </Button>
       </div>
-      <div className="rounded-2xl border border-black/10 bg-white/80 p-6 text-sm shadow-soft dark:border-white/10 dark:bg-white/[0.04]">
-        <h2 className="mb-2 text-lg font-semibold">System status</h2>
+      <div className="glass-panel rounded-[32px] p-6 text-sm">
+        <h2 className="mb-2 text-lg font-semibold text-[var(--text)] dark:text-white">
+          System status
+        </h2>
         <p className="text-muted-foreground">
           Status:{' '}
           <span

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -280,8 +280,8 @@ export function ChatWindow() {
 
   return (
     <div className="flex h-full flex-1 flex-col">
-      <ScrollArea className="flex-1 px-6 py-6">
-        <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+      <ScrollArea className="flex-1 px-8 py-8">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-7">
           {activeMessages.map((message) => (
             <MessageBubble key={message.id} message={message} />
           ))}

--- a/components/chat/Composer.tsx
+++ b/components/chat/Composer.tsx
@@ -153,8 +153,8 @@ export function Composer({
   );
 
   return (
-    <div className="border-t border-white/5 bg-transparent p-4 dark:border-white/10">
-      <div className="rounded-2xl border border-black/10 bg-white/70 p-4 shadow-pill focus-within:ring-2 focus-within:[--tw-ring-color:var(--ring)] dark:border-white/10 dark:bg-white/[0.04]">
+    <div className="border-t border-white/30 bg-white/20 px-6 py-6 backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.04]">
+      <div className="glass-panel flex flex-col gap-4 rounded-[32px] p-6">
         <Textarea
           value={message}
           onChange={(event) => setMessage(event.target.value)}
@@ -162,9 +162,9 @@ export function Composer({
           placeholder="Type your message..."
           aria-label="Message"
           disabled={Boolean(disabled || isStreaming)}
-          className="min-h-[120px] rounded-2xl border-none bg-transparent text-[var(--text)] placeholder:text-[var(--muted)] focus-visible:ring-0"
+          className="min-h-[140px] border-none bg-transparent text-[var(--text)] placeholder:text-[var(--muted)] focus-visible:ring-0 dark:text-white"
         />
-        <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="flex items-center gap-2">
             <Button
               type="button"
@@ -197,9 +197,10 @@ export function Composer({
                 </Button>
                 <Button
                   type="button"
-                  variant="outline"
+                  variant="ghost"
                   onClick={resetAudio}
                   aria-label="Discard recording"
+                  className="rounded-full px-4"
                 >
                   <Trash2 className="mr-2 h-4 w-4" /> Discard
                 </Button>
@@ -221,6 +222,7 @@ export function Composer({
               type="button"
               onClick={() => void handleSend()}
               disabled={isSendDisabled}
+              className="rounded-full px-6"
             >
               {disabled ? (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/components/chat/MessageBubble.tsx
+++ b/components/chat/MessageBubble.tsx
@@ -46,18 +46,18 @@ export function MessageBubble({ message }: MessageBubbleProps) {
       >
         <div
           className={cn(
-            'rounded-2xl p-4 shadow-sm transition',
+            'rounded-3xl p-5 shadow-soft transition-all duration-300',
             isAssistant
-              ? 'border border-white/10 bg-white/[0.03]'
-              : 'aiti-gradient text-white shadow',
+              ? 'border border-white/60 bg-white/60 text-[var(--text)] shadow-[0_28px_60px_-40px_rgba(15,23,42,0.4)] backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.05] dark:text-white'
+              : 'bg-gradient-to-r from-[#0A84FF] via-[#64D2FF] to-[#007AFF] text-white shadow-[0_30px_80px_-45px_rgba(10,132,255,0.85)]',
           )}
         >
-          <div className="flex items-center justify-between text-xs uppercase tracking-wide">
+          <div className="flex items-center justify-between text-[0.7rem] font-semibold uppercase tracking-[0.4em]">
             <div
               className={cn(
                 'font-semibold',
                 isAssistant
-                  ? 'text-[var(--text)]/70 dark:text-white/70'
+                  ? 'text-[var(--text)]/60 dark:text-white/70'
                   : 'text-white/80',
               )}
             >
@@ -66,7 +66,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
             <div className="flex items-center gap-2">
               <span
                 className={cn(
-                  'text-xs',
+                  'text-xs font-medium',
                   isAssistant
                     ? 'text-[var(--muted)] dark:text-white/60'
                     : 'text-white/80',
@@ -79,17 +79,22 @@ export function MessageBubble({ message }: MessageBubbleProps) {
                 onClick={() => void handleCopy()}
                 aria-label="Copy message"
                 className={cn(
-                  'flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-current/70 transition hover:opacity-80 focus:outline-none focus-visible:ring-2',
+                  'flex h-8 w-8 items-center justify-center rounded-full border text-current/70 transition hover:opacity-85 focus:outline-none focus-visible:ring-2',
                   isAssistant
-                    ? 'border-white/10 text-[var(--text)]/60 dark:text-white/70'
-                    : 'border-white/20 text-white/80',
+                    ? 'border-white/50 bg-white/30 text-[var(--text)]/60 backdrop-blur-md dark:border-white/15 dark:bg-white/[0.08] dark:text-white/80'
+                    : 'border-white/40 bg-white/30 text-white/80 backdrop-blur-md',
                 )}
               >
                 <ClipboardCopy className="h-4 w-4" />
               </button>
             </div>
           </div>
-          <div className="prose prose-sm mt-3 max-w-none dark:prose-invert">
+          <div
+            className={cn(
+              'prose prose-sm mt-4 max-w-none transition-colors dark:prose-invert',
+              isAssistant ? 'text-[var(--text)] dark:text-white' : 'text-white',
+            )}
+          >
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
               {message.content}
             </ReactMarkdown>

--- a/components/sidebar/ConversationList.tsx
+++ b/components/sidebar/ConversationList.tsx
@@ -152,9 +152,9 @@ export function ConversationList({
   };
 
   return (
-    <div className="h-full p-4">
-      <div className="flex h-full flex-col gap-4 rounded-2xl border border-black/5 bg-white/80 p-4 shadow-soft backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.04]">
-        <div className="flex items-center justify-between rounded-2xl border border-black/5 bg-black/5 px-3 py-2 text-sm text-[var(--text)]/80 dark:border-white/10 dark:bg-white/[0.08] dark:text-white/80">
+    <div className="flex h-full flex-col p-6">
+      <div className="glass-panel flex h-full flex-col gap-6 rounded-[32px] p-6">
+        <div className="flex items-center justify-between rounded-full border border-white/60 bg-white/50 px-4 py-2 text-sm text-[var(--text)]/80 shadow-soft backdrop-blur-lg dark:border-white/10 dark:bg-white/[0.07] dark:text-white/75">
           <div className="flex items-center gap-2">
             <Image
               src="/favicon.svg"
@@ -167,21 +167,21 @@ export function ConversationList({
           </div>
           <ThemeToggle />
         </div>
-        <div className="flex flex-col gap-3">
-          <button
+        <div className="flex flex-col gap-4">
+          <Button
             type="button"
             onClick={() => void handleCreate()}
             aria-label="New conversation"
-            className="aiti-gradient flex items-center justify-center gap-2 rounded-2xl px-4 py-2 text-sm font-medium text-white shadow-soft transition hover:opacity-90 focus:outline-none focus-visible:ring-2"
+            className="w-full justify-center rounded-[28px]"
           >
             <Plus className="h-4 w-4" /> Neu
-          </button>
+          </Button>
           <div className="flex items-center justify-between gap-2">
             <button
               type="button"
               onClick={() => void handleExport()}
               aria-label="Export conversations"
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-black/10 text-[var(--text)]/70 transition hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 dark:border-white/10 dark:text-white/70 dark:hover:text-white"
+              className="glass-button flex h-11 w-11 items-center justify-center rounded-full text-[var(--text)]/70 transition hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 dark:text-white/70 dark:hover:text-white"
             >
               <Download className="h-4 w-4" />
             </button>
@@ -189,7 +189,7 @@ export function ConversationList({
               type="button"
               onClick={() => fileInputRef.current?.click()}
               aria-label="Import conversations"
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-black/10 text-[var(--text)]/70 transition hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 dark:border-white/10 dark:text-white/70 dark:hover:text-white"
+              className="glass-button flex h-11 w-11 items-center justify-center rounded-full text-[var(--text)]/70 transition hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 dark:text-white/70 dark:hover:text-white"
             >
               <Upload className="h-4 w-4" />
             </button>
@@ -197,7 +197,7 @@ export function ConversationList({
               type="button"
               onClick={() => setCommandOpen(true)}
               aria-label="Search conversations"
-              className="surface flex flex-1 items-center gap-2 rounded-2xl border border-black/10 px-3 py-2 text-sm text-[var(--text)]/70 transition hover:border-black/20 hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
+              className="glass-button flex flex-1 items-center gap-2 rounded-full px-4 py-2 text-sm text-[var(--text)]/70 transition hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 dark:text-white/70 dark:hover:text-white"
             >
               <Search className="h-4 w-4" /> Suche (Ctrl/Cmd + K)
             </button>
@@ -212,7 +212,7 @@ export function ConversationList({
           />
         </div>
         <ScrollArea className="flex-1">
-          <div className="space-y-2">
+          <div className="space-y-2.5">
             {conversations.map((conversation) => {
               const isActive = conversation.id === activeConversationId;
               const isEditing = editingId === conversation.id;
@@ -220,10 +220,10 @@ export function ConversationList({
                 <div
                   key={conversation.id}
                   className={cn(
-                    'group flex items-center justify-between gap-2 rounded-2xl px-3 py-2 text-sm transition',
+                    'group flex items-center justify-between gap-2 rounded-[26px] px-4 py-3 text-sm transition-all duration-300',
                     isActive
-                      ? 'aiti-gradient text-white shadow'
-                      : 'border border-black/10 bg-white/70 text-[var(--text)]/80 hover:border-black/20 hover:text-[var(--text)] dark:border-white/10 dark:bg-white/[0.03] dark:text-white/70 dark:hover:bg-white/[0.08] dark:hover:text-white',
+                      ? 'bg-gradient-to-r from-[#0A84FF] via-[#64D2FF] to-[#007AFF] text-white shadow-[0_28px_80px_-50px_rgba(10,132,255,0.75)]'
+                      : 'border border-white/60 bg-white/45 text-[var(--text)]/80 backdrop-blur hover:bg-white/65 hover:text-[var(--text)] dark:border-white/10 dark:bg-white/[0.05] dark:text-white/70 dark:hover:bg-white/[0.1] dark:hover:text-white',
                   )}
                 >
                   {isEditing ? (
@@ -238,12 +238,12 @@ export function ConversationList({
                         value={newTitle}
                         onChange={(event) => setNewTitle(event.target.value)}
                         autoFocus
-                        className="h-9 rounded-2xl border-black/10 bg-white/80 text-sm text-[var(--text)] focus-visible:ring-2 dark:border-white/10 dark:bg-white/[0.05] dark:text-white"
+                        className="h-10"
                       />
                       <Button
                         type="submit"
                         size="sm"
-                        className="aiti-gradient rounded-2xl px-3 py-2 text-xs text-white shadow-soft hover:opacity-90"
+                        className="rounded-full px-4"
                       >
                         Speichern
                       </Button>
@@ -267,7 +267,7 @@ export function ConversationList({
                       <button
                         type="button"
                         aria-label="Conversation options"
-                        className="flex h-8 w-8 items-center justify-center rounded-full border border-transparent text-current/80 transition hover:text-current focus:outline-none focus-visible:ring-2"
+                        className="glass-button flex h-9 w-9 items-center justify-center rounded-full border border-white/40 text-current/80 transition hover:text-current focus:outline-none focus-visible:ring-2 dark:border-white/15"
                       >
                         <MoreHorizontal className="h-4 w-4" />
                       </button>

--- a/components/ui/ThemeToggle.tsx
+++ b/components/ui/ThemeToggle.tsx
@@ -16,7 +16,7 @@ export default function ThemeToggle() {
     <button
       aria-label="Theme umschalten"
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white shadow-soft transition hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] dark:bg-white/5 dark:text-white"
+      className="glass-button inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-[var(--text)] transition hover:opacity-95 dark:text-white"
     >
       {isDark ? <Sun size={16} /> : <Moon size={16} />}
       {isDark ? 'Light' : 'Dark'}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -7,17 +7,18 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-2xl text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        default: 'aiti-gradient text-white shadow-soft hover:opacity-95',
+        default:
+          'aiti-gradient text-white shadow-soft backdrop-blur-md transition-shadow hover:shadow-[0_28px_60px_-32px_rgba(10,132,255,0.65)] focus-visible:[--tw-ring-color:rgba(10,132,255,0.45)]',
         secondary:
-          'surface border border-black/10 text-[var(--text)]/80 shadow-soft hover:border-black/20 hover:text-[var(--text)] dark:border-white/10 dark:hover:border-white/20 dark:text-white/80',
+          'glass-button text-[var(--text)]/80 shadow-soft hover:text-[var(--text)] dark:text-white/80 dark:hover:text-white',
         outline:
-          'border border-black/10 bg-transparent text-[var(--text)]/80 shadow-sm hover:border-black/20 hover:bg-black/5 hover:text-[var(--text)] dark:border-white/20 dark:bg-transparent dark:text-white/80 dark:hover:bg-white/[0.08] dark:hover:text-white',
+          'border border-white/60 bg-white/10 px-5 text-[var(--text)]/80 shadow-soft backdrop-blur-md hover:bg-white/30 hover:text-[var(--text)] focus-visible:[--tw-ring-color:rgba(10,132,255,0.35)] dark:border-white/15 dark:bg-white/[0.04] dark:text-white/80 dark:hover:bg-white/[0.1] dark:hover:text-white',
         ghost:
-          'text-[var(--text)]/70 hover:bg-black/5 hover:text-[var(--text)] dark:text-white/70 dark:hover:bg-white/[0.08] dark:hover:text-white',
+          'text-[var(--text)]/70 hover:bg-white/40 hover:text-[var(--text)] dark:text-white/70 dark:hover:bg-white/[0.08] dark:hover:text-white',
         destructive:
           'bg-accent-red text-white shadow-soft hover:brightness-110 focus-visible:[--tw-ring-color:rgba(255,69,58,0.6)]',
         link: 'text-[var(--text)] underline-offset-4 hover:underline dark:text-white',

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-11 w-full rounded-2xl border border-black/10 bg-white/80 px-3 py-2 text-sm text-[var(--text)] shadow-sm transition file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-white/[0.05] dark:text-white',
+          'flex h-11 w-full rounded-full border border-white/60 bg-white/60 px-4 text-sm text-[var(--text)] shadow-[0_14px_32px_-24px_rgba(15,23,42,0.35)] backdrop-blur-md transition file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:rgba(10,132,255,0.4)] disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-white/[0.06] dark:text-white dark:placeholder:text-white/60',
           className,
         )}
         ref={ref}

--- a/components/ui/resizable.tsx
+++ b/components/ui/resizable.tsx
@@ -19,7 +19,7 @@ const ResizablePanel = Panel;
 const ResizableHandle = ({ className, ...props }: PanelResizeHandleProps) => (
   <PanelResizeHandle
     className={cn(
-      'w-1 cursor-col-resize bg-border transition-colors hover:bg-primary',
+      'w-px cursor-col-resize bg-white/40 transition-colors hover:bg-[rgba(10,132,255,0.6)] dark:bg-white/10',
       className,
     )}
     {...props}

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -33,13 +33,13 @@ const ScrollBar = React.forwardRef<
     className={cn(
       'flex touch-none select-none transition-colors',
       orientation === 'vertical'
-        ? 'h-full w-2 border-l border-l-transparent'
-        : 'h-2 border-t border-t-transparent',
+        ? 'h-full w-1.5 border-l border-l-transparent'
+        : 'h-1.5 border-t border-t-transparent',
       className,
     )}
     {...props}
   >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-white/60 backdrop-blur dark:bg-white/20" />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ));
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -12,12 +12,12 @@ const Switch = React.forwardRef<
   <SwitchPrimitives.Root
     ref={ref}
     className={cn(
-      'peer inline-flex h-7 w-12 shrink-0 cursor-pointer items-center rounded-full border border-black/10 bg-black/10 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-aiti-gold-500 data-[state=unchecked]:bg-black/20 dark:border-white/15 dark:bg-white/[0.05] dark:data-[state=unchecked]:bg-white/[0.08]',
+      'peer inline-flex h-8 w-14 shrink-0 cursor-pointer items-center rounded-full border border-white/60 bg-white/30 p-1 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:rgba(10,132,255,0.35)] disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[linear-gradient(120deg,#0A84FF,#64D2FF)] data-[state=unchecked]:bg-white/30 dark:border-white/15 dark:bg-white/[0.05] dark:data-[state=unchecked]:bg-white/[0.08]',
       className,
     )}
     {...props}
   >
-    <SwitchPrimitives.Thumb className="pointer-events-none block h-5 w-5 rounded-full bg-white shadow-soft ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 dark:bg-[var(--surface)]" />
+    <SwitchPrimitives.Thumb className="pointer-events-none block h-6 w-6 rounded-full bg-white shadow-[0_10px_24px_-18px_rgba(15,23,42,0.55)] transition-transform duration-200 data-[state=checked]:translate-x-6 data-[state=unchecked]:translate-x-0 dark:bg-[var(--surface-strong)]" />
   </SwitchPrimitives.Root>
 ));
 Switch.displayName = SwitchPrimitives.Root.displayName;

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'flex min-h-[120px] w-full rounded-2xl border border-black/10 bg-white/80 px-3 py-2 text-sm text-[var(--text)] shadow-sm transition placeholder:text-[var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:var(--ring)] disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-white/[0.05] dark:text-white',
+          'flex min-h-[140px] w-full rounded-[28px] border border-white/60 bg-white/60 px-4 py-3 text-base text-[var(--text)] shadow-[0_16px_36px_-28px_rgba(15,23,42,0.45)] backdrop-blur-lg transition placeholder:text-[var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:[--tw-ring-color:rgba(10,132,255,0.35)] disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-white/[0.06] dark:text-white dark:placeholder:text-white/60',
           className,
         )}
         ref={ref}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -81,8 +81,8 @@ const config: Config = {
         sans: ['var(--font-sans)', ...defaultTheme.fontFamily.sans],
       },
       boxShadow: {
-        soft: '0 2px 20px rgba(0,0,0,0.25)',
-        pill: '0 1px 12px rgba(0,0,0,0.35)',
+        soft: '0 22px 45px -28px rgba(15, 23, 42, 0.45)',
+        pill: '0 14px 36px -24px rgba(15, 23, 42, 0.4)',
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## Summary
- introduce an Apple-inspired glassmorphism theme with refreshed color tokens, gradients, and utility helpers
- restyle the chat shell, conversation list, and bubbles with translucent panels, accent gradients, and responsive chrome
- update settings and shared UI controls for rounded glass inputs, modern switches, and cohesive button styles

## Testing
- npm run lint
- npm run typecheck
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cd5ba3a4448324b7b3cb3f1c747300